### PR TITLE
expat: Add ptest

### DIFF
--- a/recipes-debian/expat/expat_debian.bb
+++ b/recipes-debian/expat/expat_debian.bb
@@ -18,14 +18,27 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=5b8620d98e49772d95fc1d291c26aa79"
 
 #  Don't build doc to reduce dependency, it depends on docbook-to-man
 SRC_URI += "file://disable-build-doc.patch \
-            file://autotools.patch"
+            file://autotools.patch \
+            file://0001-tests-Fix-macro-global-variable-and-function-usage.patch \
+            file://run-ptest \
+           "
 
 FILESEXTRAPATHS =. "${FILE_DIRNAME}/files:${COREBASE}/meta/recipes-core/expat/expat:"
 
-inherit autotools lib_package
+RDEPENDS_${PN}-ptest += "bash"
+
+inherit autotools lib_package ptest
 
 do_configure_prepend () {
 	rm -f ${S}/conftools/libtool.m4
+}
+
+do_compile_ptest() {
+	oe_runmake -C ${B}/tests runtests runtestspp
+}
+
+do_install_ptest_class-target() {
+	install -m 755 ${B}/tests/.libs/* ${D}${PTEST_PATH}
 }
 
 BBCLASSEXTEND = "native nativesdk"

--- a/recipes-debian/expat/files/0001-tests-Fix-macro-global-variable-and-function-usage.patch
+++ b/recipes-debian/expat/files/0001-tests-Fix-macro-global-variable-and-function-usage.patch
@@ -1,0 +1,69 @@
+From 6c13aa441d748df2c29ebd3365b218b26e2ec61b Mon Sep 17 00:00:00 2001
+From: Kazuho Sasaki <sasaki.kazuho@meta.co.jp>
+Date: Thu, 30 Nov 2023 14:02:03 +0900
+Subject: [PATCH] tests: Fix macro, global variable and function usage
+
+This is a follow-up patch for CVE-2022-43680.patch, which causes some
+build errors of tests.
+
+Signed-off-by: Kazuho Sasaki <sasaki.kazuho@meta.co.jp>
+---
+ tests/runtests.c | 22 +++++++++-------------
+ 1 file changed, 9 insertions(+), 13 deletions(-)
+
+diff --git a/tests/runtests.c b/tests/runtests.c
+index 14b848d..6789c1c 100644
+--- a/tests/runtests.c
++++ b/tests/runtests.c
+@@ -10772,13 +10772,9 @@ END_TEST
+ static int XMLCALL
+ external_entity_parser_create_alloc_fail_handler(XML_Parser parser,
+                                                  const XML_Char *context,
+-                                                 const XML_Char *base,
+-                                                 const XML_Char *systemId,
+-                                                 const XML_Char *publicId) {
+-  UNUSED_P(base);
+-  UNUSED_P(systemId);
+-  UNUSED_P(publicId);
+-
++                                                 const XML_Char *UNUSED_P(base),
++                                                 const XML_Char *UNUSED_P(systemId),
++                                                 const XML_Char *UNUSED_P(publicId)) {
+   if (context != NULL)
+     fail("Unexpected non-NULL context");
+ 
+@@ -10802,17 +10798,17 @@ START_TEST(test_alloc_reset_after_external_entity_parser_create_fail) {
+   const char *const text = "<!DOCTYPE doc SYSTEM 'foo'><doc/>";
+ 
+   XML_SetExternalEntityRefHandler(
+-      g_parser, external_entity_parser_create_alloc_fail_handler);
+-  XML_SetParamEntityParsing(g_parser, XML_PARAM_ENTITY_PARSING_ALWAYS);
++      parser, external_entity_parser_create_alloc_fail_handler);
++  XML_SetParamEntityParsing(parser, XML_PARAM_ENTITY_PARSING_ALWAYS);
+ 
+-  if (XML_Parse(g_parser, text, (int)strlen(text), XML_TRUE)
++  if (XML_Parse(parser, text, (int)strlen(text), XML_TRUE)
+       != XML_STATUS_ERROR)
+     fail("Call to parse was expected to fail");
+ 
+-  if (XML_GetErrorCode(g_parser) != XML_ERROR_EXTERNAL_ENTITY_HANDLING)
++  if (XML_GetErrorCode(parser) != XML_ERROR_EXTERNAL_ENTITY_HANDLING)
+     fail("Call to parse was expected to fail from the external entity handler");
+ 
+-  XML_ParserReset(g_parser, NULL);
++  XML_ParserReset(parser, NULL);
+ }
+ END_TEST
+ 
+@@ -12643,7 +12639,7 @@ make_suite(void)
+     tcase_add_test(tc_alloc, test_alloc_long_public_id);
+     tcase_add_test(tc_alloc, test_alloc_long_entity_value);
+     tcase_add_test(tc_alloc, test_alloc_long_notation);
+-    tcase_add_test__ifdef_xml_dtd(
++    tcase_add_test(
+         tc_alloc, test_alloc_reset_after_external_entity_parser_create_fail);
+ 
+     suite_add_tcase(s, tc_nsalloc);
+-- 
+2.25.1
+

--- a/recipes-debian/expat/files/run-ptest
+++ b/recipes-debian/expat/files/run-ptest
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+TIME=$(which time)
+
+echo "runtests"
+${TIME} -f 'Execution time: %e s' bash -c "./runtests -v"
+echo "runtestspp"
+${TIME} -f 'Execution time: %e s' bash -c "./runtestspp -v"
+echo


### PR DESCRIPTION
# Purpose of pull request

This PR adds ptest of expat package based on the following recipe:

* base recipe: [meta/recipes-core/expat/expat_2.5.0.bb](https://git.yoctoproject.org/poky/tree/meta/recipes-core/expat/expat_2.5.0.bb?id=3e50e45917831d9da2d86e69fb908a1a78483b62)
* base branch: master
* base commit: 3e50e45917831d9da2d86e69fb908a1a78483b62

# Note

If ptest is enabled, `CVE-2022-43680.patch` (Debian patch) causes the following build failure of test code.
`0001-tests-Fix-macro-global-variable-and-function-usage.patch` is necessary to fix this issue.

```
| In file included from ../../libexpat-R_2_2_6/expat/tests/runtests.c:78:
| ../../libexpat-R_2_2_6/expat/tests/runtests.c: In function 'external_entity_parser_create_alloc_fail_handler':
| ../../libexpat-R_2_2_6/expat/tests/../lib/internal.h:106:23: error: 'UNUSED_base' undeclared (first use in this function); did you mean 'UNUSED_P'?
|  #  define UNUSED_P(p) UNUSED_ ## p __attribute__((__unused__))
|                        ^~~~~~~
| ../../libexpat-R_2_2_6/expat/tests/runtests.c:10778:3: note: in expansion of macro 'UNUSED_P'
|    UNUSED_P(base);
|    ^~~~~~~~
| ../../libexpat-R_2_2_6/expat/tests/../lib/internal.h:106:23: note: each undeclared identifier is reported only once for each function it appears in
|  #  define UNUSED_P(p) UNUSED_ ## p __attribute__((__unused__))
|                        ^~~~~~~
| ../../libexpat-R_2_2_6/expat/tests/runtests.c:10778:3: note: in expansion of macro 'UNUSED_P'
|    UNUSED_P(base);
|    ^~~~~~~~
| ../../libexpat-R_2_2_6/expat/tests/../lib/internal.h:106:36: error: expected ';' before '__attribute__'
|  #  define UNUSED_P(p) UNUSED_ ## p __attribute__((__unused__))
|                                     ^~~~~~~~~~~~~
| ../../libexpat-R_2_2_6/expat/tests/runtests.c:10778:3: note: in expansion of macro 'UNUSED_P'
|    UNUSED_P(base);
|    ^~~~~~~~
| ../../libexpat-R_2_2_6/expat/tests/../lib/internal.h:106:23: error: 'UNUSED_systemId' undeclared (first use in this function); did you mean 'systemId'?
|  #  define UNUSED_P(p) UNUSED_ ## p __attribute__((__unused__))
|                        ^~~~~~~
| ../../libexpat-R_2_2_6/expat/tests/runtests.c:10779:3: note: in expansion of macro 'UNUSED_P'
|    UNUSED_P(systemId);
|    ^~~~~~~~
```

# Test
## How to test

1. Enable ptest and install expat package

```
$ . ./repos/poky/oe-init-build-env build
$ bitbake-layers add-layer ../repos/meta-debian/
$ cat << EOS >> conf/local.conf
DISTRO = "deby"
MACHINE = "qemuarm64"
PACKAGE_CLASSES = "package_deb"
DISTRO_FEATURES_append = " ptest"
EXTRA_IMAGE_FEATURES += "ptest-pkgs"
IMAGE_INSTALL_append = " expat"
EOS
```

2. Build core-image-minimal image

```
$ bitbake core-image-minimal
```

3. Run qemu and execute ptest of expat

```
$ runqemu nographic
...(snip)...
# ptest-runner -l
...(snip)...
# ptest-runner expat
```

Also, I confirmed that SDK builds succeed with the following settings:

* Set `DISTRO=deby` and run `bitbake core-image-minimal -c populate_sdk` with meta-debian and poky
* Set `DISTRO=emlinux` and run `bitbake core-image-minimal-sdk -c populate_sdk` with meta-debian, meta-debian-extended, meta-emlinux and poky

## Test result

```
# ptest-runner -l
Available ptests:
busybox /usr/lib/busybox/ptest/run-ptest
expat   /usr/lib/expat/ptest/run-ptest
util-linux      /usr/lib/util-linux/ptest/run-ptest
zlib    /usr/lib/zlib/ptest/run-ptest
# ptest-runner expat
START: ptest-runner
2023-12-26T00:50
BEGIN: /usr/lib/expat/ptest
runtests
[   22.313342] random: runtests: uninitialized urandom read (8 bytes read)
[   22.314496] random: runtests: uninitialized urandom read (8 bytes read)
[   22.314790] random: runtests: uninitialized urandom read (8 bytes read)
[   23.357872] random: runtests: uninitialized urandom read (8 bytes read)
[   23.403913] random: runtests: uninitialized urandom read (8 bytes read)
[   23.462170] random: runtests: uninitialized urandom read (8 bytes read)
Expat version: expat_2.2.6
100%: Checks: 335, Failed: 0
Execution time: 14.51 s
runtestspp
Expat version: expat_2.2.6
100%: Checks: 335, Failed: 0
Execution time: 14.46 s

DURATION: 29
END: /usr/lib/expat/ptest
2023-12-26T00:51
STOP: ptest-runner
```

[ptest-expat.log](https://github.com/ML-HirotakaFurukawa/meta-debian/files/13767679/ptest-expat.log)

### Test summary

* TOTAL: 670
  * PASS: 670
  * FAIL: 0

I executed this ptest 3 times and obtained the same results.