### PR TITLE
glibc: Add ptest

### DIFF
--- a/recipes-debian/glibc/glibc-tests.bb
+++ b/recipes-debian/glibc/glibc-tests.bb
@@ -1,0 +1,116 @@
+require glibc_debian.bb
+require glibc-tests.inc
+
+inherit ptest
+REQUIRED_DISTRO_FEATURES = "ptest"
+
+SRC_URI += " \
+	file://run-ptest \
+"
+
+SUMMARY = "glibc tests to be run with ptest"
+
+# Erase some variables already set by glibc_${PV}
+python __anonymous() {
+       # Remove packages provided by glibc build, we only need a subset of them
+       d.setVar("PACKAGES", "${PN} ${PN}-ptest")
+
+       d.setVar("PROVIDES", "${PN} ${PN}-ptest")
+       d.setVar("RPROVIDES", "${PN} ${PN}-ptest")
+
+       bbclassextend = d.getVar("BBCLASSEXTEND").replace("nativesdk", "").strip()
+       d.setVar("BBCLASSEXTEND", bbclassextend)
+       d.setVar("RRECOMMENDS", "")
+       d.setVar("SYSTEMD_SERVICE:nscd", "")
+       d.setVar("SYSTEMD_PACKAGES", "")
+}
+
+# Remove any leftovers from original glibc recipe
+RPROVIDES_${PN} = "${PN}"
+RRECOMMENDS_${PN} = ""
+RDEPENDS_${PN} += "glibc libgcc libstdc++ bash sed findutils"
+DEPENDS += "sed"
+
+export oe_srcdir="${exec_prefix}/src/debug/glibc/${PV}/"
+
+# Just build tests for target - do not run them
+do_check_append () {
+	oe_runmake -i check run-built-tests=no
+}
+addtask do_check after do_compile before do_install_ptest_base
+
+glibc_strip_build_directory () {
+	# Delete all non executable files from build directory
+	find ${B} ! -executable -type f -delete
+
+	# Remove build dynamic libraries and links to them as
+	# those are already installed in the target device
+	find ${B} -type f -name "*.so" -delete
+	find ${B} -type l -name "*.so*" -delete
+
+	# Remove headers (installed with glibc)
+	find ${B} -type f -name "*.h" -delete
+
+	find ${B} -type f -name "isomac" -delete
+	find ${B} -type f -name "annexc" -delete
+
+	find ${B} -type f \( -name "rpcgen" -o -name "cross-rpcgen" -o -name "mtrace" \) -delete
+}
+
+do_install_ptest () {
+	glibc_strip_build_directory
+
+	ls -r ${B}/*/tst-* |sed 's|/[^/]*$||' |sort |uniq > ${B}/tst_list
+	tet_items=$(cat ${B}/tst_list)
+
+	rm ${B}/tst_list
+	echo "${tet_items}"
+
+	# Install build test programs to the image
+	install -d ${D}${PTEST_PATH}/tests/glibc-ptest/
+
+	for f in "${tet_items}"
+	do
+	    cp -r ${f} ${D}${PTEST_PATH}/tests/glibc-ptest/
+	done
+
+	cp ${WORKDIR}/run-ptest ${D}${PTEST_PATH}/
+}
+
+# The datadir directory is required to allow core (and reused)
+# glibc cleanup function to finish correctly, as this directory
+# is not created for ptests
+stash_locale_package_cleanup_prepend () {
+	mkdir -p ${PKGD}${datadir}
+}
+
+stash_locale_sysroot_cleanup_prepend () {
+	mkdir -p ${SYSROOT_DESTDIR}${datadir}
+}
+
+# Prevent the do_package() task to set 'libc6' prefix
+# for glibc tests related packages
+python populate_packages_prepend () {
+    if d.getVar('DEBIAN_NAMES'):
+        d.setVar('DEBIAN_NAMES', '')
+}
+
+FILES_${PN} = "${PTEST_PATH}/* /usr/src/debug/${PN}/*"
+
+EXCLUDE_FROM_SHLIBS = "1"
+
+# Install debug data in .debug and sources in /usr/src/debug
+# It is more handy to have _all_ the sources and symbols in one
+# place (package) as this recipe will be used for validation and
+# debugging.
+PACKAGE_DEBUG_SPLIT_STYLE = ".debug"
+
+# glibc test cases violate by default some Yocto/OE checks (staticdev,
+# textrel)
+# 'debug-files' - add everything (including debug) into one package
+#                 (no need to install/build *-src package)
+INSANE_SKIP_${PN} += "staticdev textrel debug-files rpaths"
+
+deltask do_stash_locale
+do_install[noexec] = "1"
+do_populate_sysroot[noexec] = "1"

--- a/recipes-debian/glibc/glibc-tests.inc
+++ b/recipes-debian/glibc/glibc-tests.inc
@@ -1,0 +1,32 @@
+EXCLUDE_FROM_WORLD = "1"
+
+# handle PN differences
+FILESEXTRAPATHS_prepend := "${THISDIR}/glibc:"
+
+# setup depends
+INHIBIT_DEFAULT_DEPS = ""
+
+python () {
+    libc = d.getVar("PREFERRED_PROVIDER_virtual/libc")
+    libclocale = d.getVar("PREFERRED_PROVIDER_virtual/libc-locale")
+    if libc != "glibc" or libclocale != "glibc-locale":
+        raise bb.parse.SkipRecipe("glibc-testsuite requires that virtual/libc is glibc")
+}
+
+DEPENDS += "glibc-locale libgcc gcc-runtime"
+
+# remove the initial depends
+DEPENDS_remove = "libgcc-initial"
+
+do_check[dirs] += "${B}"
+do_check () {
+    # clean out previous test results
+    oe_runmake tests-clean
+    # makefiles don't clean entirely (and also sometimes fails due to too many args)
+    find ${B} -type f -name "*.out" -delete
+    find ${B} -type f -name "*.test-result" -delete
+    find ${B}/catgets -name "*.cat" -delete
+    find ${B}/conform -name "symlist-*" -delete
+    [ ! -e ${B}/timezone/testdata ] || rm -rf ${B}/timezone/testdata
+}
+addtask do_check after do_compile

--- a/recipes-debian/glibc/glibc/run-ptest
+++ b/recipes-debian/glibc/glibc/run-ptest
@@ -1,0 +1,27 @@
+#!/bin/sh
+# ptest script for glibc - to run time related tests to
+# facilitate Y2038 validation
+# Run with 'ptest-runner glibc-tests'
+
+output() {
+  retcode=$?
+  if [ $retcode -eq 0 ]
+    then echo "PASS: $i"
+  elif [ $retcode -eq 77 ]
+    then echo "SKIP: $i"
+  else echo "FAIL: $i"
+  fi
+}
+
+# Allow altering time on the target
+export GLIBC_TEST_ALLOW_TIME_SETTING="1"
+
+tst_items=$(find ${PWD}/tests/glibc-ptest/ -name '.debug' -prune -o -type f -name 'tst-*' -print)
+
+# Run tests
+for i in ${tst_items}
+do
+	$i >/dev/null 2>&1
+	output
+done
+

--- a/recipes-debian/glibc/glibc_debian.bb
+++ b/recipes-debian/glibc/glibc_debian.bb
@@ -171,3 +171,11 @@ FILES_${PN} += "${sysconfdir}/nsswitch.conf"
 FILES_${PN} += "${base_libdir}/libcrypt*.so.* ${base_libdir}/libcrypt-*.so"
 
 BBCLASSEXTEND = "nativesdk"
+
+PTEST_ENABLED = "${@bb.utils.contains('DISTRO_FEATURES', 'ptest', '1', '0', d)}"
+PTEST_ENABLED_class-native = ""
+PTEST_ENABLED_class-nativesdk = ""
+PTEST_ENABLED_class-cross-canadian = ""
+PACKAGES += "${@bb.utils.contains('PTEST_ENABLED', '1', 'glibc-ptest', '', d)}"
+ALLOW_EMPTY_glibc-ptest = "1"
+RDEPENDS_glibc-ptest_class-target = "glibc-tests"


### PR DESCRIPTION
# Purpose of pull request

This PR adds ptest of glibc package based on the following recipe:

* base recipe: [meta/recipes-core/glibc/glibc_2.35.bb](https://git.yoctoproject.org/poky/tree/meta/recipes-core/glibc/glibc-tests_2.35.bb?id=f966e16c3bf59a4e174675e9e45518d5f14ada2d)
* base branch: kirkstone
* base commit: f966e16c3bf59a4e174675e9e45518d5f14ada2d

# Note

Tests of glibc depends on libgcc, and libgcc depends on glibc.
Therefore, it causes circular build-dependency between glibc and libgcc.

To avoid this circular build-dependency, test code of glibc is split out as "glibc-tests" recipe in current implementation.
As a result,

* libgcc depends on glibc
* glibc-tests depends on glibc,

and then glibc-tests is build-able.

This relationship is the same as that of dbus and dbus-test in meta-debian.

# Test

## How to test

1.Enable ptest and install glibc package
```
$ . ./repos/poky/oe-init-build-env build
$ bitbake-layers add-layer ../repos/meta-debian/
$ cat << EOS >> conf/local.conf
DISTRO = "deby"
MACHINE = "qemuarm64"
PACKAGE_CLASSES = "package_deb"
DISTRO_FEATURES_append = " ptest"
EXTRA_IMAGE_FEATURES += "ptest-pkgs"
IMAGE_INSTALL_append = " glibc"
EOS
```
 
2.Build core-image-minimal
```
$ bitbake core-image-minimal
```

3.Run qemu and execute ptest of glibc
```
$ runqemu nographic qemuparams="-m 1024"
...(snip)...
# ptest-runner -l
...(snip)...
# ptest-runner -t -1 glibc
```

## Test result

[ptest-run.sh](https://github.com/ML-HirotakaFurukawa/meta-debian/files/13764211/ptest-run.sh.txt)
[ptest-result-count.sh](https://github.com/ML-HirotakaFurukawa/meta-debian/files/13764214/ptest-result-count.sh.txt)
```
# ptest-runner -l
Available ptests:
busybox /usr/lib/busybox/ptest/run-ptest
glibc   /usr/lib/glibc/ptest/run-ptest
util-linux      /usr/lib/util-linux/ptest/run-ptest
zlib    /usr/lib/zlib/ptest/run-ptest
# ptest-runner -t -1 glibc
START: ptest-runner
2023-12-28T00:25
BEGIN: /usr/lib/glibc/ptest
PASS: /usr/lib/glibc/ptest/tests/glibc-ptest/localedata/tst-langinfo-setlocale-static
PASS: /usr/lib/glibc/ptest/tests/glibc-ptest/localedata/tst-ctype
PASS: /usr/lib/glibc/ptest/tests/glibc-ptest/localedata/tst-langinfo-newlocale-static
...(snip)...
PASS: /usr/lib/glibc/ptest/tests/glibc-ptest/dirent/tst-scandir64
PASS: /usr/lib/glibc/ptest/tests/glibc-ptest/dirent/tst-seekdir
PASS: /usr/lib/glibc/ptest/tests/glibc-ptest/dirent/tst-fdopendir
DURATION: 1536
END: /usr/lib/glibc/ptest
2023-12-28T00:51
STOP: ptest-runner
```

[ptest-glibc.log](https://github.com/ML-HirotakaFurukawa/meta-debian/files/13782642/ptest-glibc.log)

## Test summary

* TOTAL: 1014
  * PASS:  820
  * FAIL:  189
  * SKIP:  5

I executed this ptest 3 times and obtained the same results.