### PR TITLE
nftables: Add ptest

### DIFF
--- a/recipes-debian/nftables/nftables/0001-tests-shell-validate-too-deep-jumpstack-from-basecha.patch
+++ b/recipes-debian/nftables/nftables/0001-tests-shell-validate-too-deep-jumpstack-from-basecha.patch
@@ -1,0 +1,32 @@
+From bd3466544d3d65ea6ecc0283ac0d7a9d2abcbc05 Mon Sep 17 00:00:00 2001
+From: Pablo Neira Ayuso <pablo@netfilter.org>
+Date: Wed, 8 Aug 2018 21:52:50 +0200
+Subject: [PATCH] tests: shell: validate too deep jumpstack from basechain
+
+If there is no basechain, the validation is never exercised.
+
+Too deep nested chains are fine as long as they are not connected to a
+basechain.
+
+Update test to add a basechain so we exercise validation.
+
+Signed-off-by: Pablo Neira Ayuso <pablo@netfilter.org>
+---
+ tests/shell/testcases/chains/0002jumps_1 | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/tests/shell/testcases/chains/0002jumps_1 b/tests/shell/testcases/chains/0002jumps_1
+index 0cc8928..4d163b0 100755
+--- a/tests/shell/testcases/chains/0002jumps_1
++++ b/tests/shell/testcases/chains/0002jumps_1
+@@ -6,7 +6,9 @@ MAX_JUMPS=16
+ 
+ $NFT add table t
+ 
+-for i in $(seq 1 $MAX_JUMPS)
++$NFT add chain t c1 { type filter hook input priority 0\; }
++
++for i in $(seq 2 $MAX_JUMPS)
+ do
+ 	$NFT add chain t c${i}
+ done

--- a/recipes-debian/nftables/nftables/run-ptest
+++ b/recipes-debian/nftables/nftables/run-ptest
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+NFTABLESLIB=@libdir@/nftables
+cd ${NFTABLESLIB}/ptest
+
+LOG="${NFTABLESLIB}/ptest/nftables_ptest_$(date +%Y%m%d-%H%M%S).log"
+tests/shell/run-tests.sh -v 2>&1 | sed  -e '/I: \[OK\]/ s/^/PASS: / ; /W: \[\(FAILED\|DUMP FAIL\)\]/ s/^/FAIL: /' | sed "s,\x1B\[[0-9;]*[a-zA-Z],,g" | tee -a ${LOG}
+
+passed=`grep PASS: ${LOG}|wc -l`
+failed=`grep FAIL: ${LOG}|wc -l`
+all=$((passed + failed))
+
+(   echo "=== Test Summary ==="
+    echo "TOTAL: ${all}"
+    echo "PASSED: ${passed}"
+    echo "FAILED: ${failed}"
+) | tee -a ${LOG}

--- a/recipes-debian/nftables/nftables_debian.bb
+++ b/recipes-debian/nftables/nftables_debian.bb
@@ -11,7 +11,12 @@ require recipes-debian/sources/nftables.inc
 
 DEPENDS = "libmnl libnftnl readline gmp bison-native"
 
-inherit autotools manpages pkgconfig
+SRC_URI += " \
+    file://0001-tests-shell-validate-too-deep-jumpstack-from-basecha.patch \
+    file://run-ptest \
+"
+
+inherit autotools manpages pkgconfig ptest
 
 PACKAGECONFIG ?= ""
 PACKAGECONFIG[manpages] = "--enable--man-doc, --disable-man-doc"
@@ -32,8 +37,6 @@ do_install_append() {
 	install -m 0644 ${S}/debian/examples/sysvinit/nftables.init ${D}${docdir}/nftables/examples/sysvinit
 }
 
-PACKAGES = "${PN} ${PN}-dbg ${PN}-dev ${PN}-src"
-
 FILES_${PN} += "${systemd_system_unitdir}/nftables.service \
                 ${docdir}/nftables/examples/*.nft \
                 ${docdir}/nftables/examples/sysvinit/* \
@@ -42,3 +45,22 @@ FILES_${PN} += "${systemd_system_unitdir}/nftables.service \
 ASNEEDED = ""
 
 RRECOMMENDS_${PN} += "kernel-module-nf-tables"
+
+RDEPENDS_${PN}-ptest += "bash findutils make iproute2 iputils-ping procps sed util-linux"
+
+TESTDIR = "tests"
+
+PRIVATE_LIBS_${PN}-ptest_append = " libnftables.so.0"
+
+do_install_ptest() {
+    cp -rf ${S}/build-aux ${D}${PTEST_PATH}
+    cp -rf ${S}/src ${D}${PTEST_PATH}
+    mkdir -p ${D}${PTEST_PATH}/src/.libs
+    cp -rf ${B}/src/.libs/* ${D}${PTEST_PATH}/src/.libs
+    cp -rf ${B}/src/.libs/nft ${D}${PTEST_PATH}/src/
+    cp -rf ${S}/${TESTDIR} ${D}${PTEST_PATH}/${TESTDIR}
+    # avoid python dependency
+    rm -rf ${D}${PTEST_PATH}/${TESTDIR}/py
+    # handle multilib
+    sed -i s:@libdir@:${libdir}:g ${D}${PTEST_PATH}/run-ptest
+}


### PR DESCRIPTION
# Purpose of pull request

This PR adds ptest of nftables based on the following recipe:

* base recipe: [meta-networking/recipes-filter/nftables/nftables_1.0.9.bb](https://git.openembedded.org/meta-openembedded/tree/meta-networking/recipes-filter/nftables/nftables_1.0.9.bb?id=3991d85383b466a4948283cfd0167213a1dd2311)
* base branch: master
* base commit: 3991d85383b466a4948283cfd0167213a1dd2311

# Note

`0001-tests-shell-validate-too-deep-jumpstack-from-basecha.patch` will fix `chains/0002jumps_1`.
This test fails as follows without this patch:

```
I: [EXECUTING]  ./tests/shell/testcases/chains/0002jumps_1
FAIL: W: [FAILED]       ./tests/shell/testcases/chains/0002jumps_1: expected 1 but got 0
E: max jumps ignored?
```

This is upstream issue and fixed on [760a8bab07ade570e589bc8da36935776d225d95](https://git.netfilter.org/nftables/commit/?id=760a8bab07ade570e589bc8da36935776d225d95), so this PR backports this commit as `0001-tests-shell-validate-too-deep-jumpstack-from-basecha.patch`.

# Test
## How to test

1. Add kernel configurations to enable nftables

Apply the following change to meta-debian
```diff
diff --git a/recipes-kernel/linux/linux-base_git.bb b/recipes-kernel/linux/linux-base_git.bb
index ca0814ac..fe0c6d8e 100644
--- a/recipes-kernel/linux/linux-base_git.bb
+++ b/recipes-kernel/linux/linux-base_git.bb
@@ -116,3 +116,5 @@ KERNEL_PRIORITY = "1"
 
 # extra tasks
 addtask kernel_link_images after do_compile before do_strip
+
+SRC_URI += "${@bb.utils.contains("DISTRO_FEATURES", "ptest", "file://ptest.config","", d)}"
```

Also, create the following kernel configurations to `recipes-kernel/linux/files/ptest.config` in meta-debian

<details>
<summary>ptest.config (click to expand)</summary>

```
CONFIG_NF_CONNTRACK=y
CONFIG_NF_LOG_COMMON=y
CONFIG_NF_LOG_NETDEV=y
CONFIG_NF_CONNTRACK_MARK=y
CONFIG_NF_CONNTRACK_SECMARK=y
CONFIG_NF_CONNTRACK_ZONES=y
CONFIG_NF_CONNTRACK_PROCFS=y
CONFIG_NF_CONNTRACK_EVENTS=y
CONFIG_NF_CONNTRACK_TIMEOUT=y
CONFIG_NF_CONNTRACK_TIMESTAMP=y
CONFIG_NF_CONNTRACK_LABELS=y
CONFIG_NF_CT_PROTO_DCCP=y
CONFIG_NF_CT_PROTO_GRE=y
CONFIG_NF_CT_PROTO_SCTP=y
CONFIG_NF_CT_PROTO_UDPLITE=y
CONFIG_NF_CONNTRACK_AMANDA=y
CONFIG_NF_CONNTRACK_FTP=y
CONFIG_NF_CONNTRACK_H323=y
CONFIG_NF_CONNTRACK_IRC=y
CONFIG_NF_CONNTRACK_BROADCAST=y
CONFIG_NF_CONNTRACK_NETBIOS_NS=y
CONFIG_NF_CONNTRACK_SNMP=y
CONFIG_NF_CONNTRACK_PPTP=y
CONFIG_NF_CONNTRACK_SANE=y
CONFIG_NF_CONNTRACK_SIP=y
CONFIG_NF_CONNTRACK_TFTP=y
CONFIG_NF_CT_NETLINK=y
CONFIG_NF_CT_NETLINK_TIMEOUT=y
CONFIG_NF_CT_NETLINK_HELPER=y
CONFIG_NF_NAT=y
CONFIG_NF_NAT_NEEDED=y
CONFIG_NF_NAT_PROTO_DCCP=y
CONFIG_NF_NAT_PROTO_UDPLITE=y
CONFIG_NF_NAT_PROTO_SCTP=y
CONFIG_NF_NAT_AMANDA=y
CONFIG_NF_NAT_FTP=y
CONFIG_NF_NAT_IRC=y
CONFIG_NF_NAT_SIP=y
CONFIG_NF_NAT_TFTP=y
CONFIG_NF_NAT_IPV4=y
CONFIG_NF_NAT_IPV6=y
CONFIG_NF_NAT_REDIRECT=y
CONFIG_NF_TABLES=y
CONFIG_NF_TABLES_SET=y
CONFIG_NF_TABLES_INET=y
CONFIG_NF_TABLES_NETDEV=y
CONFIG_NF_DUP_NETDEV=y
CONFIG_NF_FLOW_TABLE_INET=y
CONFIG_NF_FLOW_TABLE_IPV4=y
CONFIG_NF_FLOW_TABLE_IPV6=y
CONFIG_NF_FLOW_TABLE=y
CONFIG_NF_TABLES=y
CONFIG_NF_TABLES_ARP=y
CONFIG_NF_TABLES_BRIDGE=y
CONFIG_NF_TABLES_INET=y
CONFIG_NF_TABLES_IPV4=y
CONFIG_NF_TABLES_IPV6=y
CONFIG_NF_TABLES_NETDEV=y
CONFIG_NF_TABLES_SET=y
CONFIG_NFT_NUMGEN=y
CONFIG_NFT_CT=y
CONFIG_NFT_FLOW_OFFLOAD=y
CONFIG_NFT_COUNTER=y
CONFIG_NFT_CONNLIMIT=y
CONFIG_NFT_LOG=y
CONFIG_NFT_LIMIT=y
CONFIG_NFT_MASQ=y
CONFIG_NFT_REDIR=y
CONFIG_NFT_NAT=y
CONFIG_NFT_TUNNEL=y
CONFIG_NFT_OBJREF=y
CONFIG_NFT_QUOTA=y
CONFIG_NFT_REJECT=y
CONFIG_NFT_COMPAT=y
CONFIG_NFT_HASH=y
CONFIG_NFT_SOCKET=y
CONFIG_NFT_OSF=y
CONFIG_NFT_TPROXY=y
CONFIG_NFT_DUP_NETDEV=y
CONFIG_NFT_FWD_NETDEV=y
CONFIG_NFT_CHAIN_ROUTE_IPV4=y
CONFIG_NFT_DUP_IPV4=y
CONFIG_NFT_FIB_IPV4=y
CONFIG_NFT_CHAIN_NAT_IPV4=y
CONFIG_NFT_MASQ_IPV4=y
CONFIG_NFT_MASQ_IPV6=y
CONFIG_NFT_REDIR_IPV4=y
CONFIG_NFT_REDIR_IPV6=y
CONFIG_NFT_CHAIN_ROUTE_IPV6=y
CONFIG_NFT_CHAIN_NAT_IPV6=y
CONFIG_NFT_DUP_IPV6=y
CONFIG_NFT_FIB_IPV6=y
CONFIG_IP_SET=y
CONFIG_IP_NF_NAT=y
CONFIG_IP_NF_TARGET_MASQUERADE=y
CONFIG_IP_NF_TARGET_NETMAP=y
CONFIG_IP_NF_TARGET_REDIRECT=y
CONFIG_IP_NF_MANGLE=y
CONFIG_IP6_NF_NAT=y
CONFIG_IP6_NF_TARGET_MASQUERADE=y
CONFIG_IP6_NF_MANGLE=y
```
</details>

2. Enable ptest and install nftables package

```
$ . ./repos/poky/oe-init-build-env build
$ bitbake-layers add-layer ../repos/meta-debian/
$ cat << EOS >> conf/local.conf
DISTRO = "deby"
MACHINE = "qemuarm64"
PACKAGE_CLASSES = "package_deb"
DISTRO_FEATURES_append = " ptest"
EXTRA_IMAGE_FEATURES += "ptest-pkgs"
IMAGE_INSTALL_append = " nftables"
EOS
```

3. Build core-image-minimal image

```
$ bitbake core-image-minimal
```

4. Run qemu and execute ptest of nftables

NOTE: Some tests hang-up for a while and ptest-runner kills them before they resume, so add "-t -1" argument to avoid that.

```
$ runqemu nographic
...(snip)...
# ptest-runner -l
...(snip)...
# ptest-runner -t -1 nftables
```

Also, I confirmed that SDK builds succeed with the following settings:

* Set `DISTRO=deby` and run `bitbake core-image-minimal -c populate_sdk` with meta-debian and poky
* Set `DISTRO=emlinux` and run `bitbake core-image-minimal-sdk -c populate_sdk` with meta-debian, meta-debian-extended, meta-emlinux and poky

## Test result

```
# ptest-runner -l
Available ptests:
busybox /usr/lib/busybox/ptest/run-ptest
nftables        /usr/lib/nftables/ptest/run-ptest
util-linux      /usr/lib/util-linux/ptest/run-ptest
zlib    /usr/lib/zlib/ptest/run-ptest
# ptest-runner -t -1 nftables
START: ptest-runner
2023-12-26T09:07
BEGIN: /usr/lib/nftables/ptest
[   21.524936] random: mktemp: uninitialized urandom read (10 bytes read)
[   41.511851] random: mktemp: uninitialized urandom read (10 bytes read)
[   41.551708] random: mktemp: uninitialized urandom read (10 bytes read)
[   42.085940] random: mktemp: uninitialized urandom read (10 bytes read)
[   42.707767] random: mktemp: uninitialized urandom read (10 bytes read)
[   42.785460] random: mktemp: uninitialized urandom read (10 bytes read)
I: using nft binary tests/shell/../../src/nft

I: [EXECUTING]  ./tests/shell/testcases/cache/0001_cache_handling_0
PASS: I: [OK]           ./tests/shell/testcases/cache/0001_cache_handling_0
I: [EXECUTING]  ./tests/shell/testcases/cache/0002_interval_0
PASS: I: [OK]           ./tests/shell/testcases/cache/0002_interval_0
I: [EXECUTING]  ./tests/shell/testcases/chains/0001jumps_0
PASS: I: [OK]           ./tests/shell/testcases/chains/0001jumps_0
...(snip)...
I: [EXECUTING]  ./tests/shell/testcases/transactions/0041nat_restore_0
PASS: I: [OK]           ./tests/shell/testcases/transactions/0041nat_restore_0

I: results: [OK] 155 [FAILED] 3 [TOTAL] 158
=== Test Summary ===
TOTAL: 158
PASSED: 155
FAILED: 3
DURATION: 637
END: /usr/lib/nftables/ptest
2023-12-26T09:17
STOP: ptest-runner
```

[ptest-nftables.log](https://github.com/ML-HirotakaFurukawa/meta-debian/files/13774308/ptest-nftables.log)

## Test summary

* TOTAL: 158
  * PASS: 155
  * FAIL: 3

I executed this ptest 3 times and obtained the same results.

## Excuse of failures

`import/vm_json_import_0`
```
I: [EXECUTING]  ./tests/shell/testcases/import/vm_json_import_0
FAIL: W: [FAILED]       ./tests/shell/testcases/import/vm_json_import_0: expected 0 but got 1
/dev/stdin:37:15-15: Error: Could not process rule: No such file or directory
        chain y {
                     ^
...(snip)...
/dev/stdin:44:17-97: Error: Could not process rule: No such file or directory
                ip6 daddr fe00::1-fe00::200 udp dport domain counter packets 0 bytes 0 masquerade
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
unable to import: parsing failed: Operation not supported
Error: Could not process rule: Operation not supported
import vm json
^^^^^^^^^^^^^^^
```

This test requires JSON support of nftables (`--with-json=yes` is required in configure).
However, currently nftables recipe of meta-debian doesn't support this (`--with-json=no` is default), so we are unable to execute this test.

`sets/0026named_limit_0`
```
I: [EXECUTING]  ./tests/shell/testcases/sets/0026named_limit_0
FAIL: W: [DUMP FAIL]    ./tests/shell/testcases/sets/0026named_limit_0: dump diff detected
--- ./tests/shell/testcases/sets/dumps/0026named_limit_0.nft
+++ /dev/fd/63
@@ -1,6 +1,6 @@
 table ip filter {
        limit http-traffic {
-               rate 1/second
+               rate 1/second burst 5 packets
        }

        chain input {
```

The exit code of this test is as expected, but the dump of ruleset of nftables is slightly different than that is expected.
I think this is not a serious issue because the test itself suceeded.

`sets/0028autoselect_0`
```
FAIL: W: [FAILED]       ./tests/shell/testcases/sets/0028autoselect_0: expected 0 but got 1
Error: Could not process rule: Operation not supported
add rule t c meta iifname foobar add @s1 { ip protocol }
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

According to [the commit which added this test](https://git.netfilter.org/nftables/commit/?id=d988eb4029e049fcaf3a4f68a076b72cc32c3022), Linux kernel may cause the error.
I'm not sure, but we have to update or fix the kernel in order to make this test pass.