### PR TITLE
db: Add ptest

### DIFF
--- a/recipes-debian/db/db/run-ptest
+++ b/recipes-debian/db/db/run-ptest
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+output() {
+  retcode=$?
+  if [ $retcode -eq 0 ]
+    then echo "PASS: $test"
+  elif [ $retcode -eq 77 ]
+    then echo "SKIP: $test"
+  else echo "FAIL: $test"
+  fi
+}
+
+suites='DB_ALL_TEST_SUITES'
+
+# Run tests
+for test in ${suites}
+do
+  ${PWD}/lt-cutest -s $test >/dev/null 2>&1
+  output
+done
+
+exit 0


### PR DESCRIPTION
<h1>Purpose of pull request</h1>

This PR adds ptest of db package based on the following test code:

<ul>
<li>package: db-5.3.28</li>
<li>test code directory path: db-5.3.28/test</li>
</ul>
couldn't find any reference recipes that add ptest.

<h1>Test</h1>

<h2>How to test</h2>

1.Enable ptest and install db package
```
$ . setup-emlinux
$ cat <<EOF >> conf/local.conf
MACHINE = "qemuarm64"
DISTRO_FEATURES_append = " ptest"
CORE_IMAGE_EXTRA_INSTALL += "ptest-runner db-ptest"
EOF
```
 
2.Build core-image-minimal
```
$ bitbake core-image-minimal
```

3.Run qemu and execute ptest of db5.3
```
$ runqemu qemuarm64 qemuparams="-m 1024 -nographic -serial mon:stdio"
...(snip)...
# ptest-runner -l
...(snip)...
# ptest-runner db5.3
```

<h2>Test result</h2>

```
root@qemuarm64:~# ptest-runner -l
Available ptests:
db5.3   /usr/lib/db5.3/ptest/run-ptest
root@qemuarm64:~# ptest-runner db5.3
START: ptest-runner
2023-12-13T05:45
BEGIN: /usr/lib/db5.3/ptest
PASS: TestChannel
/usr/lib/db5.3/ptest/run-ptest: line 16:  2064 Segmentation fault      ${PWD}/lt-cutest -s $test > /dev/null 2>&1
FAIL: TestDbHotBackup
PASS: TestDbTuner
PASS: TestEncryption
PASS: TestEnvConfig
PASS: TestEnvMethod
PASS: TestKeyExistErrorReturn
PASS: TestPartial
PASS: TestQueue
DURATION: 43
END: /usr/lib/db5.3/ptest
2023-12-13T05:46
STOP: ptest-runner
```

Segmentation fault is a defect in the test code.
db-5.3.28/test/c/suites/TestDbHotBackup.c:
```
    /* Set queue record length and extent size. */
    if (envconf == QUEUE_DB) {
        if ((ret = dbp->set_re_len(dbp, 50)) != 0) {
            dbp->err(dbp, ret, "DB->set_re_len");
            return (ret);
        }
        if ((ret = dbp->set_q_extentsize(dbp, 1)) != 0) {
            dbp->err(dbp, ret, "DB->set_q_extentsize");
            return (ret);
        }
    }
```
dbp->set_q_extentsize is NULL.